### PR TITLE
Improve Docker configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,26 @@
 FROM ruby:2.6.3
 
-# Make NodeJS and Yarn
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+# Install apt-transport-https
+RUN apt-get update
+RUN apt-get install -y apt-transport-https
 
-# Install dependencies and perform clean-up
-RUN apt-get update -qq
-RUN apt-get install -y build-essential nodejs yarn postgresql-client nano vim
+# Add NodeJS repo
+RUN curl -sS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+RUN echo "deb https://deb.nodesource.com/node_8.x stretch main" > /etc/apt/sources.list.d/node.list
+
+# Add Yarn repo
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
+
+# Install packages
+RUN apt-get update
+RUN apt-get install -y nodejs yarn postgresql-client nano vim
+
+# Clean up
 RUN apt-get -q clean
 RUN rm -rf /var/lib/apt/lists
 
 WORKDIR /usr/src/app
-ENV RAILS_ENV development
 
 # Install Ruby dependencies
 COPY Gemfile* ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get -q clean
 RUN rm -rf /var/lib/apt/lists
 
 WORKDIR /usr/src/app
+ENV DISABLE_SPRING 1
 
 # Install Ruby dependencies
 COPY Gemfile* ./

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -6,5 +6,8 @@ end
 
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+# Set up gems listed in the Gemfile.
+require 'bundler/setup'
+
+# Speed up boot time by caching expensive operations.
+require 'bootsnap/setup' unless ENV['DISABLE_SPRING'] == 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       - db
       - cache
     environment:
-      RAILS_ENV: development
       DATABASE_URL: postgres://postgres:@db:5432
       REDIS_CACHE: redis://cache:6379/1
       REDIS_STORE: redis://cache:6379/1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,10 @@ services:
       context: .
     ports:
       - "3000:3000"
+    networks:
+        - backend
+    volumes:
+      - .:/usr/src/app
     depends_on:
       - db
       - cache
@@ -13,8 +17,6 @@ services:
       DATABASE_URL: postgres://postgres:@db:5432
       REDIS_CACHE: redis://cache:6379/1
       REDIS_STORE: redis://cache:6379/1
-    volumes:
-      - .:/usr/src/app
     command: bundle exec rails server -b 0.0.0.0
   worker:
     ports: []
@@ -22,12 +24,14 @@ services:
     command: bundle exec sidekiq
   db:
     image: postgres
-    restart: always
-    ports:
-      - "5432:5432"
+    networks:
+        - backend
     environment:
       POSTGRES_DB: roombooking_development
   cache:
     image: redis
-    ports:
-      - "6379:6379"
+    networks:
+        - backend
+networks:
+  backend:
+    driver: bridge


### PR DESCRIPTION
This PR fixes #85

- Creates a segmented network inside Docker which the app server & background worker use to communicate with Postgres & Redis. This network is totally inaccessible except by the containers in question, so external hosts can't connect to the database or cache. The only externally accessible port is `3000/tcp` on which web pages are served.
- Prevents the Postgres container from auto-(re)starting with the Docker daemon.

@GKFX could you do a review from your end if possible just to double check my sanity? In the end I decided not to bother adding a password as it would be hard-coded in plaintext in `docker-compose.yml`.